### PR TITLE
use env-based AWS access keys instead of profiles

### DIFF
--- a/api/dynamo.py
+++ b/api/dynamo.py
@@ -5,10 +5,14 @@ import boto3
 import flask_api
 
 
+AWS_DYNAMO_ACCESS_KEY = os.environ.get('AWS_DYNAMO_ACCESS_KEY')
+AWS_DYNAMO_SECRET_KEY = os.environ.get('AWS_DYNAMO_SECRET_KEY')
+
 DYNAMO_TABLE = os.environ.get('DYNAMO_TABLE', 'calligre-posts')
 DYNAMO_REGION = os.environ.get('DYNAMO_REGION', 'us-west-2')
 
-dynamo_boto = boto3.Session(profile_name='dynamo')
+dynamo_boto = boto3.Session(aws_access_key_id=AWS_DYNAMO_ACCESS_KEY,
+                            aws_secret_access_key=AWS_DYNAMO_SECRET_KEY)
 dynamo = dynamo_boto.resource('dynamodb',
                               region_name=DYNAMO_REGION).Table(DYNAMO_TABLE)
 

--- a/api/gunicorn.conf.py
+++ b/api/gunicorn.conf.py
@@ -20,3 +20,8 @@ _ = os.environ['DB_USER']
 
 _ = os.environ['AUTH0_CLIENT_ID']
 _ = os.environ['AUTH0_SECRET_ID']
+
+_ = os.environ['AWS_DYNAMO_ACCESS_KEY']
+_ = os.environ['AWS_DYNAMO_SECRET_KEY']
+_ = os.environ['AWS_SNS_ACCESS_KEY']
+_ = os.environ['AWS_SNS_SECRET_KEY']

--- a/api/models/social.py
+++ b/api/models/social.py
@@ -15,6 +15,9 @@ import flask_restful.reqparse
 from api import database, dynamo
 
 
+AWS_SNS_ACCESS_KEY = os.environ.get('AWS_SNS_ACCESS_KEY')
+AWS_SNS_SECRET_KEY = os.environ.get('AWS_SNS_SECRET_KEY')
+
 MAX_POSTS = 25
 PROFILE_PIC_BCKT = os.environ.get('PROFILE_PIC_BUCKET', 'calligre-profilepics')
 EXT_POSTS_TOPIC = 'arn:aws:sns:us-west-2:037954390517:calligre-external-posts'
@@ -215,7 +218,8 @@ class SocialContentList(flask_restful.Resource):
         log.debug('Posting to FB: %s; posting to Twitter: %s', fb, tw)
 
         try:
-            sns_boto = boto3.Session(profile_name='sns')
+            sns_boto = boto3.Session(aws_access_key_id=AWS_SNS_ACCESS_KEY,
+                                     aws_secret_access_key=AWS_SNS_SECRET_KEY)
             client = sns_boto.client('sns')
             response = client.publish(**params)
             log.debug('Message sent: %s', response.get('MessageId'))


### PR DESCRIPTION
A couple reasons for this:

1) Current master won't run unless the box has a 'dynamo' global profile in their aws creds file. This includes dev boxes with no intention of using the social API.
2) Using env vars puts our configuration in the same place as all the other configuration. Besides making it easier to have that all in one place, this will be convenient if we ever plan to use a real secret share.
3) ???
4) Profit!

Thoughts?