### PR TITLE
dump images straight into final bucket while other stuff is worked on

### DIFF
--- a/api/models/social.py
+++ b/api/models/social.py
@@ -237,7 +237,7 @@ class SocialContentUploadURL(flask_restful.Resource):
         # TODO: specify auth?
         s3 = boto3.client('s3')
         post_url = s3.generate_presigned_post(
-            Bucket='calligre-images-pending-resize',
+            Bucket='calligre-images',
             Key=''.join(random.choice(string.ascii_uppercase + string.digits)
                         for _ in range(12))
         )


### PR DESCRIPTION
Yay workarounds so that people can test end to end without needing the resize functionality up and running just yet.