### PR TITLE
Add social url rewrite

### DIFF
--- a/api/.gitignore
+++ b/api/.gitignore
@@ -1,1 +1,7 @@
 *.pyc
+__pycache__
+bin
+include
+lib
+.cache
+api.*.log

--- a/api/models/social.py
+++ b/api/models/social.py
@@ -170,9 +170,9 @@ class SocialContentList(flask_restful.Resource):
         if args.get('media_link'):
             try:
                 u = urlparse(args.get('media_link'))
-                if u.netloc == "%s.s3.amazonaws.com" % RESIZE_BUCKET:
+                if u.netloc == "{}.s3.amazonaws.com".format(RESIZE_BUCKET):
                     params['Item']['media_link'] = \
-                        "https://%s.s3.amazonaws.com%s" % (
+                        "https://{}.s3.amazonaws.com{}".format(
                             UPLOAD_BUCKET,
                             u.path
                         )


### PR DESCRIPTION
We currently return the pre-signed PUT url as the location of the uploaded image. 

Now that we have auto-resizing of images, we can change any request that uploaded a file to our to-be-resized bucket to use the actual final URL.