### PR TITLE
Fix reserved words usage in Dynamo

### DIFF
--- a/api/models/social.py
+++ b/api/models/social.py
@@ -444,7 +444,10 @@ class FlaggedPostList(flask_restful.Resource):
 
         params = {
             'Limit': limit,
-            'ProjectionExpression': 'timestamp',
+            'ProjectionExpression': '#ts',
+            'ExpressionAttributeNames': {
+                '#ts': 'timestamp',
+            }
         }
 
         if args.get('offset'):


### PR DESCRIPTION
Originally this was post_id, which wasn't a reserved word. 

Then for consistency, it was renamed to timestamp.

:|