### PR TITLE
Remove IAM keys

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -38,7 +38,8 @@ logger.addHandler(logging.StreamHandler(sys.stdout))
 app = flask.Flask(__name__)
 app.secret_key = SECRET_KEY
 app.url_map.strict_slashes = False
-sentry = Sentry(app, logging=True, level=logging.INFO)
+if os.environ.get('SENTRY_DSN'):
+    sentry = Sentry(app, logging=True, level=logging.INFO)
 
 
 restful = flask_restful.Api(app, prefix='/api')

--- a/api/dynamo.py
+++ b/api/dynamo.py
@@ -52,14 +52,10 @@ def expect_empty_return(response):
 
 class DynamoWrapper:
     def __init__(self,
-                 table_name=os.environ.get('DYNAMO_TABLE', 'calligre-posts'),
-                 region=os.environ.get('DYNAMO_REGION', 'us-west-2'),
-                 access_key=os.environ.get('AWS_DYNAMO_ACCESS_KEY'),
-                 secret_key=os.environ.get('AWS_DYNAMO_SECRET_KEY')):
+                 table_name,
+                 region=os.environ.get('DYNAMO_REGION', 'us-west-2')):
 
-        self._boto = boto3.Session(aws_access_key_id=access_key,
-                                   aws_secret_access_key=secret_key)
-        self.dynamo = self._boto.resource('dynamodb', region_name=region)
+        self.dynamo = boto3.resource('dynamodb', region_name=region)
         self.table = self.dynamo.Table(table_name)
 
     def get(self, params):

--- a/api/gunicorn.conf.py
+++ b/api/gunicorn.conf.py
@@ -23,8 +23,3 @@ _ = os.environ['DB_USER']
 
 _ = os.environ['AUTH0_CLIENT_ID']
 _ = os.environ['AUTH0_SECRET_ID']
-
-_ = os.environ['AWS_DYNAMO_ACCESS_KEY']
-_ = os.environ['AWS_DYNAMO_SECRET_KEY']
-_ = os.environ['AWS_SNS_ACCESS_KEY']
-_ = os.environ['AWS_SNS_SECRET_KEY']

--- a/api/models/social.py
+++ b/api/models/social.py
@@ -18,9 +18,6 @@ from api import database, dynamo
 from api.auth import requires_admin, requires_auth
 
 
-AWS_SNS_ACCESS_KEY = os.environ.get('AWS_SNS_ACCESS_KEY')
-AWS_SNS_SECRET_KEY = os.environ.get('AWS_SNS_SECRET_KEY')
-
 MAX_POSTS = 25
 UPLOAD_BUCKET = os.environ.get('UPLOAD_BUCKET', 'calligre-images')
 RESIZE_BUCKET = os.environ.get('RESIZE_BUCKET',
@@ -262,9 +259,7 @@ class SocialContentList(flask_restful.Resource):
         log.debug('Posting to FB: %s; posting to Twitter: %s', fb, tw)
 
         try:
-            sns_boto = boto3.Session(aws_access_key_id=AWS_SNS_ACCESS_KEY,
-                                     aws_secret_access_key=AWS_SNS_SECRET_KEY)
-            client = sns_boto.client('sns')
+            client = boto3.client('sns')
             response = client.publish(**params)
             log.debug('Message sent: %s', response.get('MessageId'))
         except Exception as e:


### PR DESCRIPTION
Fixes #62, and stops Sentry complaining about a shared creds file.

Replacement for outside of AWS hosting: people who run it have a default IAM key in ~/.aws/credentials

