### PR TITLE
Use strings for postids, and add checks for decimalness

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -71,11 +71,11 @@ restful.add_resource(api.models.social.FlaggedPostList, '/social/flags')
 restful.add_resource(api.models.social.SocialContentUploadURL,
                      '/social-image-upload-url')
 restful.add_resource(api.models.social.SingleSocialContent,
-                     '/social/<float:postid>')
+                     '/social/<str:postid>')
 restful.add_resource(api.models.social.SingleSocialContentLikes,
-                     '/social/<float:postid>/likes')
+                     '/social/<str:postid>/likes')
 restful.add_resource(api.models.social.PostFlag,
-                     '/social/<float:postid>/flag')
+                     '/social/<str:postid>/flag')
 
 restful.add_resource(api.models.stream.StreamList, '/stream')
 


### PR DESCRIPTION
Currently, we rely on werkzeug to check if a post id is a float, and we convert it to a Decimal.

Now, we actually have half-decent checking for decimalness, so we can use strings.

(Alternative for the endpoints with a path in them: http://werkzeug.pocoo.org/docs/0.11/routing/#custom-converters. But that's extra work with #70 will get rid of.)

This will close https://github.com/Calligre/lambda-functions/issues/1.