### PR TITLE
us-east-2 S3 buckets have a different naming scheme when built by boto3

### DIFF
--- a/api/models/social.py
+++ b/api/models/social.py
@@ -304,7 +304,7 @@ class SocialContentUploadURL(flask_restful.Resource):
         post_url = boto3.client('s3').generate_presigned_url(
             "put_object", {
                 "Bucket": RESIZE_BUCKET,
-                "Key": '{}-{}'.format(userid.replace('|', '-'), suffix),
+                "Key": '{}-{}.jpg'.format(userid.replace('|', '-'), suffix),
                 "ContentType": args['Content-Type']
             }
         )

--- a/api/models/social.py
+++ b/api/models/social.py
@@ -245,7 +245,7 @@ class SocialContentList(flask_restful.Resource):
         return {'data': data}, flask_api.status.HTTP_201_CREATED
 
     @staticmethod
-    def external_post(req_userid, message, media_s3, fb, tw):
+    def external_post(req_userid, message, media_link, fb, tw):
         params = {
             'TopicArn': EXT_POSTS_TOPIC,
             'Message': message,
@@ -266,16 +266,16 @@ class SocialContentList(flask_restful.Resource):
             },
         }
 
-        if media_s3:
-            params['MessageAttributes']['media_s3'] = {
+        if media_link:
+            params['MessageAttributes']['media_link'] = {
                 'DataType': 'String',
-                'StringValue': media_s3,
+                'StringValue': media_link,
             }
 
         log.debug('%s saying "%s", with media %s',
                   req_userid,
                   message,
-                  media_s3)
+                  media_link)
         log.debug('Posting to FB: %s; posting to Twitter: %s', fb, tw)
 
         try:

--- a/api/models/social.py
+++ b/api/models/social.py
@@ -5,7 +5,7 @@ import random
 import string
 import time
 from decimal import Decimal, InvalidOperation
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlunparse
 
 import boto3
 from boto3.dynamodb.conditions import Attr, Key, Not
@@ -220,7 +220,6 @@ class SocialContentList(flask_restful.Resource):
                     log.exception(ex)
             else:
                 params['Item']['media_link'] = args.get('media_link')
-
 
         r, status = posts_table.put(params)
         if not flask_api.status.is_success(status):

--- a/api/models/social.py
+++ b/api/models/social.py
@@ -210,7 +210,7 @@ class SocialContentList(flask_restful.Resource):
                 try:
                     split_url = urlparse(url)
                     # Throw away the query string since that contains the sig
-                    split_url._replace(query="")
+                    split_url = split_url._replace(query="")
                     params['Item']['media_link'] = urlunparse(split_url)
                     log.debug("Rewrote %s to %s",
                               args.get('media_link'),

--- a/api/models/social.py
+++ b/api/models/social.py
@@ -228,7 +228,7 @@ class SocialContentList(flask_restful.Resource):
         if args.get('post_fb') or args.get('post_tw'):
             self.external_post(userid,
                                args.get('text'),
-                               args.get('media_link'),
+                               params['Item']['media_link'],
                                args.get('post_fb', False),
                                args.get('post_tw', False))
 

--- a/api/models/social.py
+++ b/api/models/social.py
@@ -29,7 +29,7 @@ DEFAULT_PROFILE_PIC = os.environ.get('DEFAULT_PROFILE_PIC',
                                      'https://s3-us-west-2.amazonaws.com/'
                                      'calligre-profilepics/default.png')
 POSTS_TABLE_NAME = os.environ.get('POSTS_TABLE', 'calligre-posts')
-FLAG_TABLE_NAME = os.environ.get('FLAGS_TABLE', 'flagged')
+FLAG_TABLE_NAME = os.environ.get('FLAG_TABLE', 'flagged')
 REGION = os.environ.get('DYNAMO_REGION', 'us-west-2')
 posts_table = dynamo.DynamoWrapper(table_name=POSTS_TABLE_NAME)
 flag_table = dynamo.DynamoWrapper(table_name=FLAG_TABLE_NAME)


### PR DESCRIPTION
Instead of {bucket}.s3.amazonaws.com, it uses s3.us-east-2.amazonaws.com/{bucket}. 
Really: the presigned url is `https://s3.us-east-2.amazonaws.com/calligre-squirrel-resize-imagependingresizebucket-eppnr7k111mg/facebook-10207943757254134-21539HHXHOAU?X-Amz-Date=20170328...`

So instead of trying to be smart, just do a string replacement to change the bucket name, and throw away the query parameter since that has the signature, which is (obviously) invalid because the bucket has changed.

Abuse is unlikely - both bucket names are public, and people don't have permission to read anything from the resize bucket. They wouldn't get any benefit from changing the URLs.